### PR TITLE
Fix quiz navigation

### DIFF
--- a/quiz.js
+++ b/quiz.js
@@ -110,7 +110,8 @@ window.addEventListener("DOMContentLoaded", function () {
         document.getElementById("mark-correct-btn").style.display = "none";
         document.getElementById("mark-wrong-btn").style.display = "none";
         quitQuizBtn.style.display = show ? "inline-block" : "none";
-        nextQuestionBtn.style.display = show ? "none" : "inline-block";
+        // Always hide the next question button until a choice is made
+        nextQuestionBtn.style.display = "none";
         document.getElementById("next-btn").style.display = show ? "none" : "inline-block";
         reverseModeCheckbox.parentElement.style.display = show ? "block" : "none";
         scoreDisplay.style.display = show ? "block" : "none";

--- a/script.js
+++ b/script.js
@@ -55,5 +55,6 @@ window.addEventListener("DOMContentLoaded", function () {
         loadCategory(e.target.value);
     });
 
-
+    // Display words for the default selected category on initial load
+    loadCategory(categorySelect.value);
 });


### PR DESCRIPTION
## Summary
- load words for default category on page load
- hide the quiz next button whenever toggling quiz UI

## Testing
- `node --check script.js`
- `node --check quiz.js`


------
https://chatgpt.com/codex/tasks/task_e_6841df8e8e88832082abe206838b88d1

## Summary by Sourcery

Improve quiz navigation by loading the default category on startup and ensuring the next question button remains hidden until a choice is made.

Bug Fixes:
- Always hide the next question button until a user selects an answer, preventing it from appearing during UI toggles.

Enhancements:
- Load words for the default category on initial page load.